### PR TITLE
sorting tasks before saving to file

### DIFF
--- a/src/main/scala/com/workflowfm/simulator/metrics/Output.scala
+++ b/src/main/scala/com/workflowfm/simulator/metrics/Output.scala
@@ -281,7 +281,7 @@ class SimD3Timeline(path: String, file: String, tick: Int = 1)
   def build(aggregator: SimMetricsAggregator, now: Long) = {
     var buf: StringBuilder = StringBuilder.newBuilder
     buf.append("var tasks = [\n")
-    for (p <- aggregator.taskSet) buf.append(s"""\t"$p",\n""")
+    for (p <- (collection.immutable.SortedSet[String]() ++ aggregator.taskSet) ) buf.append(s"""\t"$p",\n""")
     buf.append("];\n\n")
     buf.append("var resourceData = [\n")
     for (m <- aggregator.resourceMetrics) buf.append(s"""${resourceEntry(m, aggregator)}\n""")


### PR DESCRIPTION
Orders tasks before adding them to the output file, so that tasks in the D3 Timeline have the same colour every simulation run.
Identical to the change that should be made in PEW in accordance to PetrosPapapa/WorkflowFM-PEW#60.
