### PR TITLE
Handles collections of Flows

### DIFF
--- a/proter/src/main/scala/com/workflowfm/proter/flows/Flow.scala
+++ b/proter/src/main/scala/com/workflowfm/proter/flows/Flow.scala
@@ -72,9 +72,7 @@ class Or(val left: Flow, val right: Flow) extends Flow {
 }
 
 object Flow {
-  def apply(): NoTask = new NoTask()
-
-  def apply(t: Task): FlowTask = new FlowTask(t)
+  def apply(t: Task*): Flow = Flow.seq(t.map(new FlowTask(_)))
 
   implicit def flowOfTask(t: Task): FlowTask = new FlowTask(t)
 

--- a/proter/src/main/scala/com/workflowfm/proter/flows/Flow.scala
+++ b/proter/src/main/scala/com/workflowfm/proter/flows/Flow.scala
@@ -78,8 +78,24 @@ object Flow {
 
   implicit def flowOfTask(t: Task): FlowTask = new FlowTask(t)
 
+  /**
+    * Creates a sequence of a collection of [[Flow]]s.
+    *
+    * @see [[Then]]
+    * @example Flow.seq(Seq(t1,t2,t3)) = t1 > t2 > t3    
+    * @param l The collection of [[Flow]]s
+    * @return A [[Flow]] that executes the given collection in sequence
+    */
   def seq(l: Seq[Flow]): Flow = (l.foldRight[Flow](new NoTask()) { (l, r) => new Then(l, r) })
 
+  /**
+    * Creates a parallel [[Flow]] from a collection of [[Flow]]s.
+    *
+    * @see [[And]]
+    * @example Flow.par(Seq(t1,t2,t3)) = t1 | t2 | t3    
+    * @param l The collection of [[Flow]]s
+    * @return A [[Flow]] that executes the given collection in parallel
+    */
   def par(l: Seq[Flow]): Flow = (l.foldRight[Flow](new NoTask()) { (l, r) => new And(l, r) })
 }
 


### PR DESCRIPTION
- Introduces `Flow.seq` and `Flow.par` to compose collections of `Flow`s in sequence and in parallel respectively.
- Removes `All` as it is basically the equivalent of `Flow.par` (i.e. a sequence of `And`s) so there is no need for an extra constructor.
- Improves `Flow.apply` to take a sequence `Task*` argument, using `Flow.seq`.