### PR TITLE
Adds task priority to metrics

### DIFF
--- a/proter/src/main/scala/com/workflowfm/proter/Task.scala
+++ b/proter/src/main/scala/com/workflowfm/proter/Task.scala
@@ -318,9 +318,9 @@ object Task {
   ): Task =
     Task(name, Some(id), Constant(duration))
 
-  val Highest: Int = 5
-  val High: Int = 4
-  val Medium: Int = 3
-  val Low: Int = 2
-  val VeryLow: Int = 1
+  val Highest: Int = 2
+  val High: Int = 1
+  val Medium: Int = 0
+  val Low: Int = -1
+  val VeryLow: Int = -2
 }

--- a/proter/src/main/scala/com/workflowfm/proter/metrics/Measure.scala
+++ b/proter/src/main/scala/com/workflowfm/proter/metrics/Measure.scala
@@ -9,6 +9,7 @@ import com.workflowfm.proter._
   * @param id the unique ID of the [[TaskInstance]]
   * @param task the name of the [[TaskInstance]]
   * @param simulation the name of the simulation the [[TaskInstance]] belongs to
+  * @param priority the priority of the [[TaskInstance]]
   * @param created the virtual timestamp when the [[TaskInstance]] was created and entered the [[Coordinator]]
   * @param started the virtual timestamp when the [[TaskInstance]] started executing, or [[scala.None]] if it has not started yet
   * @param duration the virtual duration of the [[TaskInstance]]
@@ -19,6 +20,7 @@ case class TaskMetrics(
     id: UUID,
     task: String,
     simulation: String,
+    priority: Int,
     created: Long,
     started: Option[Long],
     duration: Long,
@@ -69,6 +71,7 @@ object TaskMetrics {
     task.id,
     task.name,
     task.simulation,
+    task.priority,
     task.created,
     None,
     task.duration,

--- a/proter/src/main/scala/com/workflowfm/proter/metrics/Output.scala
+++ b/proter/src/main/scala/com/workflowfm/proter/metrics/Output.scala
@@ -107,6 +107,7 @@ trait SimMetricsStringOutput extends SimMetricsOutput {
       "ID",
       "Task",
       "Simulation",
+      "Priority",
       "Created",
       "Start",
       "Delay",
@@ -124,11 +125,12 @@ trait SimMetricsStringOutput extends SimMetricsOutput {
     * @param m the [[TaskMetrics]] instance to be handled
     */
   def taskCSV(separator: String, resSeparator: String)(m: TaskMetrics): String = m match {
-    case TaskMetrics(id, task, sim, ct, st, dur, cost, res, aborted) =>
+    case TaskMetrics(id, task, sim, priority, ct, st, dur, cost, res, aborted) =>
       Seq(
         id,
         task,
         sim,
+        priority,
         ct,
         SimMetricsOutput.formatOption(st, nullValue),
         m.delay,
@@ -345,7 +347,7 @@ $times
       val finish = (tstart + m.duration) * tick
       val delay = m.delay * tick
       Some(
-        s"""\t{"label":"${m.fullName}", task: "${m.task}", "id":"${m.id}", "starting_time": $start, "ending_time": $finish, delay: $delay, cost: ${m.cost}}"""
+        s"""\t{"label":"${m.fullName}", task: "${m.task}", "id":"${m.id}", "priority": ${m.priority}, "starting_time": $start, "ending_time": $finish, delay: $delay, cost: ${m.cost}}"""
       )
     }
   }


### PR DESCRIPTION
`TaskMetrics` now also record the task's priority.

Named priorities are also adjusted so that `Task.Medium` matches the default `0`.